### PR TITLE
Fix for LinuxVDA on Ubuntu

### DIFF
--- a/linuxvda/map.jinja
+++ b/linuxvda/map.jinja
@@ -18,6 +18,9 @@
     'Fedora': {
       'normalname': 'XenDesktopVDA',
      },
+    'Ubuntu': {
+      'pkgs': ['xserver-xorg-core',' xserver-xorg','ubuntu-desktop','libxm4','libsasl2-2','libsasl2-modules-gssapi-mit','libldap-2.4-2','cups','libpostgresql-jdbc-java',]
+     },
    }, grain='os')
 )%}
 


### PR DESCRIPTION
People have reported to Citrix that LinuxVDA does not work on Ubuntu, and grey screen is typically observed.  Troubleshooting logs does not give indication.   This PR fixes this issue by ensuring  'xserver-xorg-core' package is installed.   Solution verified on Ubuntu 16.04 vanilla install.
