### PR TITLE
Add FQDN resolver (127.0.1.1) state; Add all services

### DIFF
--- a/linuxvda/config.sls
+++ b/linuxvda/config.sls
@@ -6,6 +6,13 @@
 include:
   - linuxvda.pkg
 
+127.0.1.1:
+  host.only:
+    - hostnames:
+      - {{ salt['grains.get']('fqdn') }}
+      - {{ salt['grains.get']('host') }}
+      - 'salt'
+
   {% for config in linuxvda.nsswitch.regex %}
 linuxvda_nsswitch_{{ config[0] }}:
   file.replace:

--- a/linuxvda/defaults.yaml
+++ b/linuxvda/defaults.yaml
@@ -8,6 +8,13 @@ linuxvda:
   services:
     - ctxhdx
     - ctxvda
+    - ctxcdm
+    - ctxceip
+    - ctxcups
+    - ctxlogd
+    - ctxpolicyd
+    - ctxusbsd
+    - ctxvhcid
   pkgs:
     - gperftools-libs
     - postgresql-jdbc


### PR DESCRIPTION
This PR ensures FQDN resolver is defined in /etc/hosts, and extends the list of services owned by LinuxVDA. Verified on Fedora27.