### PR TITLE
Add linuxvda.xdping state

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,12 +26,17 @@ Meta-state for inclusion of all states (except remove).
 ``linuxvda.pkg``
 --------------------
 
-Download Linux VDA package, validate hashsum, and install the software.
+Download Linux VDA package from `linuxvda.citrix.uri`, validate the hashsum, and install.
 
 ``linuxvda.config``
 --------------------
 
 Disable mDNS in nsswitch.conf, execute Linux VDA setup script, and start services.
+
+``linuxvda.xdping``
+--------------------
+
+Download XDPing package from `linuxvda.citrix.uri`, validate the hashsum, and install.
 
 ``linuxvda.remove``
 --------------------------
@@ -74,3 +79,41 @@ Setting the following pillars should be sufficient.
         uri: http://download.example.com/xendesktop/
         variables:
           CTX_XDL_DDC_LIST: ubuntu-dc.example.com
+
+Common problems
+=======================
+
+Compare host's assigned (dhcp) ipaddress with DNS recorded ipaddress! Sometimes the values are out of sync.
+
+.. code-block:: bash
+
+     [myhost]$ ip addr
+     [myhost]$ host myhost.example.com
+
+Ensure system time is NTP synchronized (yes)!!
+
+.. code-block:: bash
+
+     $ # timedatectl
+               Local time: Fri 2018-02-09 08:34:10 MST
+           Universal time: Fri 2018-02-09 15:34:10 UTC
+                 RTC time: Fri 2018-02-09 15:34:21
+                Time zone: America/Denver (MST, -0700)
+          Network time on: yes
+         NTP synchronized: yes
+          RTC in local TZ: no
+
+If VDA Agent uses port 80 (default yes), check and fix port collisions with apache2, nginx, etc.
+
+.. code-block:: bash
+
+     $ netstat -a | grep :80
+
+Run the Citrix XDping tool from the `linuxvda.xdping` state. Fix any big issues and run formula again.
+
+.. code-block:: bash
+
+     $ # xdping
+
+
+

--- a/linuxvda/config.sls
+++ b/linuxvda/config.sls
@@ -3,15 +3,25 @@
 
 {% from "linuxvda/map.jinja" import linuxvda with context %}
 
+{%- set fqdn = salt['grains.get']('fqdn') %}
+{%- if fqdn == salt['grains.get']('host') %}
+  {%- set dn = salt['pillar.get']('linuxvda:domain') or None %}
+  {%- if dn %}
+    {%- set fqdn = fqdn ~ "." ~ dn %}
+  {%- endif %}
+{%- endif %}
+  
 include:
   - linuxvda.pkg
 
 127.0.1.1:
   host.only:
     - hostnames:
-      - {{ salt['grains.get']('fqdn') }}
+      - {{ fqdn }}
       - {{ salt['grains.get']('host') }}
-      - 'salt'
+      {% if linuxvda.fqdn_resolver_alias %}
+      - {{ linuxvda.fqdn_resolver_alias }}
+      {% endif %}
 
   {% for config in linuxvda.nsswitch.regex %}
 linuxvda_nsswitch_{{ config[0] }}:

--- a/linuxvda/defaults.yaml
+++ b/linuxvda/defaults.yaml
@@ -2,9 +2,18 @@
 # vim: ft: yaml
 
 linuxvda:
-  normalname: xendesktopvda
+  #Ubuntu values..
+  packagename: xendesktopvda
   src_pkg: XenDesktopVDA-7.16.0.412-1.el7_x.x86_64.rpm
   src_hash: sha256=8b75157869fda9db2a8bebeffee75619fcda4d9dcadac62f013d4f89a7a6ffe6
+  fqdn_resolver_alias:
+  enable_ntp_timesync: timedatectl set-ntp True
+
+  xdping:
+    package:
+    archive: linux-xdping.tar
+    hash: sha256=38cf8ff42cd0d610ba7323689046cd1492db912c9f722932e99c13869301186a
+    cmd: /usr/bin/xdping
   services:
     - ctxhdx
     - ctxvda

--- a/linuxvda/init.sls
+++ b/linuxvda/init.sls
@@ -6,6 +6,7 @@
 include:
   - linuxvda.pkg
   - linuxvda.config
+  - linuxvda.xdping
 
 extend:
   {%- for svc in linuxvda.services %}

--- a/linuxvda/map.jinja
+++ b/linuxvda/map.jinja
@@ -2,30 +2,39 @@
 # vim: ft=jinja
 
 {% set osmap = salt['grains.filter_by']({
-  'default':{
-   },
+  'default':{ 'packagename': 'XenDesktopVDA', },
+
+  'RedHat':{ 'packagename': 'XenDesktopVDA',
+             'pkgs': ['pulseaudio',] },
+
   'Debian': {
     'src_pkg': 'xendesktopvda_7.16.0.412-1.ubuntu16.04_amd64.deb',
     'src_hash': 'fc48ad39be54cae0034e9302908aa146',
-    'pkgs': ['libxm4', 'libsasl2-2', 'libsasl2-modules-gssapi-mit', 'libldap-2.4-2', 'cups', 'libpostgresql-jdbc-java',]
-  },
+    'pkgs': ['libxm4', 'libsasl2-2', 'libsasl2-modules-gssapi-mit', 'libldap-2.4-2', 'cups', 'libpostgresql-jdbc-java',], },
+
  'Suse':{
     'src_pkg': 'XenDesktopVDA-7.16.0.412-1.sle12_x.x86_64.rpm',
     'src_hash': 'sha256=57bd03ee4a01cce9a01571eba668b0dcc34787a9f7a4b8a637696172860206f7',
-    'pkgs': ['libxm4', 'cups', 'foomatic-filters', 'imageMagick', 'libsasl2-2-gssapi', 'libldap-2_4-2', 'gperftools', 'libecpg6', 'postgresql-jdbc',],
-   },
+    'pkgs': ['libxm4', 'cups', 'foomatic-filters', 'imageMagick', 'libsasl2-2-gssapi', 'libldap-2_4-2', 'gperftools', 'libecpg6', 'postgresql-jdbc',], },
+
  }, grain='os_family', merge=salt['grains.filter_by']({
     'Fedora': {
-      'normalname': 'XenDesktopVDA',
-     },
+      'packagename': 'XenDesktopVDA', },
+
     'Ubuntu': {
-      'pkgs': ['xserver-xorg-core',' xserver-xorg','ubuntu-desktop','libxm4','libsasl2-2','libsasl2-modules-gssapi-mit','libldap-2.4-2','cups','libpostgresql-jdbc-java',]
-     },
-   }, grain='os')
-)%}
+      'pkgs': ['xserver-xorg-core',' xserver-xorg','ubuntu-desktop','libxm4','libsasl2-2','libsasl2-modules-gssapi-mit','libldap-2.4-2','cups','libpostgresql-jdbc-java',], },
+
+   }, grain='os'))%}
+
+{% set xdping_osmap = salt['grains.filter_by']({
+  'default': { 'package': 'linux-xdping/RHEL/xdping-7.13.1-0.x86_64.rpm', },
+  'Debian': { 'package': 'linux-xdping/Ubuntu/xdping_7.13.1-0_amd64.deb', },
+  'Suse':{ 'package': 'linux-xdping/SuSE/xdping-7.13.1-0.x86_64.rpm', },
+ }, grain='os_family')%}
 
 {# start with defaults, merge osmaps and then pillars #}
 {% import_yaml "linuxvda/defaults.yaml" as defaults %}
 {% do defaults.linuxvda.update( osmap ) %}
+{% do defaults.linuxvda.xdping.update( xdping_osmap ) %}
 {% set linuxvda = salt['pillar.get']( 'linuxvda', default=defaults.linuxvda, merge=True) %}
 

--- a/linuxvda/pkg.sls
+++ b/linuxvda/pkg.sls
@@ -15,6 +15,10 @@ linuxvda_dependencies:
     {% endfor %}
     - require_in:
       - pkg: linuxvda_package
+    {%- if linuxvda.enable_ntp_timesync %}
+  cmd.run:
+    - name: {{ linuxvda.enable_ntp_timesync }}
+    {%- endif %}
 
 linuxvda_package:
   cmd.run:
@@ -33,5 +37,5 @@ linuxvda_package:
       - pkg: linuxvda_package
   pkg.installed:
     - sources:
-      - {{ linuxvda.normalname }}: {{ linuxvda.dl.tmpdir }}/{{ linuxvda.src_pkg }}
+      - {{ linuxvda.packagename }}: {{ linuxvda.dl.tmpdir }}/{{ linuxvda.src_pkg }}
 

--- a/linuxvda/remove.sls
+++ b/linuxvda/remove.sls
@@ -16,7 +16,11 @@ linuxvda_remove:
     - name: {{ linuxvda.citrix.ctxcleanup }}
     - onlyif: test -f {{ linuxvda.citrix.ctxcleanup }}
   pkg.removed:
-    - name: {{ linuxvda.normalname }}
+    - pkgs:
+      - {{ linuxvda.packagename }}
+      - xendesktopvda
+      - XenDesktopVDA
+      - xdping
     - require:
       - cmd: linuxvda_remove
   file.absent:

--- a/linuxvda/xdping.sls
+++ b/linuxvda/xdping.sls
@@ -1,0 +1,69 @@
+{% from "linuxvda/map.jinja" import linuxvda with context %}
+
+{% if linuxvda.xdping.archive %}
+
+linuxvda_xdping_tmpdir:
+  file.directory:
+    - name: '{{ linuxvda.dl.tmpdir }}'
+    - clean: True
+    - makedirs: True
+    - require_in:
+      - cmd: linuxvda_xdping_download_archive
+    - unless: test -d '{{ linuxvda.dl.tmpdir }}'
+
+linuxvda_xdping_download_archive:
+  cmd.run:
+    - name: curl -o {{linuxvda.dl.tmpdir}}/{{linuxvda.xdping.archive}} {{linuxvda.citrix.uri ~ linuxvda.xdping.archive}}
+    {% if grains['saltversioninfo'] >= [2017, 7, 0] %}
+    - retry:
+      attempts: {{ linuxvda.dl.retries }}
+      interval: {{ linuxvda.dl.interval }}
+    {% endif %}
+
+    {%- if linuxvda.xdping.hash %}
+linuxvda_xdping-check-archive-hash:
+   # Check local archive using hashstring for older Salt / MacOS.
+  module.run:
+    - name: file.check_hash
+    - path: {{ linuxvda.dl.tmpdir }}/{{ linuxvda.xdping.archive }}
+    - file_hash: {{ linuxvda.xdping.hash }}
+    - onlyif: test -f {{ linuxvda.dl.tmpdir }}/{{ linuxvda.xdping.archive }}
+    - onchanges:
+      - cmd: linuxvda_xdping_download_archive
+    - require_in:
+      - archive: linuxvda_xdping_archive_extract
+    {%- endif %}
+
+linuxvda_xdping_archive_extract:
+  archive.extracted:
+    - source: 'file://{{ linuxvda.dl.tmpdir }}/{{ linuxvda.xdping.archive }}'
+    - name: '{{ linuxvda.dl.tmpdir }}'
+    - archive_format: tar
+    - onchanges:
+      - cmd: linuxvda_xdping_download_archive
+    - require_in:
+      - pkg: linuxvda_xdping_package_install
+       {% if grains['saltversioninfo'] < [2016, 11, 0] %}
+    - if_missing: '{{ linuxvda.xdping.cmd }}'
+       {% endif %}
+
+linuxvda_xdping_package_install:
+  cmd.run:
+    - name: {{ linuxvda.dl.tmpdir }}/linux-xdping/uninstall.sh || echo "not installed"
+    - onlyif: test -f {{ linuxvda.dl.tmpdir }}/linux-xdping/uninstall.sh
+    - require_in:
+      - pkg: linuxvda_xdping_package_install
+  pkg.installed:
+    - sources:
+      - xdping: {{ linuxvda.dl.tmpdir }}/{{ linuxvda.xdping.package }}
+    - require:
+      - archive: linuxvda_xdping_archive_extract
+    - onlyif: test -f {{ linuxvda.dl.tmpdir }}/{{ linuxvda.xdping.package }}
+
+linuxvda_xdping_remove_tmpdir:
+  file.absent:
+    - name: '{{ linuxvda.dl.tmpdir }}'
+    - require:
+      - pkg: linuxvda_xdping_package_install
+
+{% endif %}

--- a/pillar.example
+++ b/pillar.example
@@ -1,4 +1,10 @@
 linuxvda:
+  enable_ntp_timesync: timedatectl set-ntp True
+
+  #fqdn_resolver_alias: 'salt'
+  # If salt sets bad fqdn in /etc/hosts, the set domain here to fix things.
+  #domain: example.com
+
   citrix:
     #uri value must be supplied here
     uri: https://www.example.com/downloads/xen/linuxvda/
@@ -8,4 +14,7 @@ linuxvda:
     variables:
       #Site specific configuration
       CTX_XDL_DDC_LIST: citrixdc1.example.com
+  xdping:
+    archive: linux-xdping.tar
+    hash: sha256=38cf8ff42cd0d610ba7323689046cd1492db912c9f722932e99c13869301186a
 


### PR DESCRIPTION
This tool is essential: https://support.citrix.com/article/CTX202015

```
[WARNING ] State is set to retry, but a valid dict for retry configuration was not found.  Using retry defaults
[WARNING ] The function "module.run" is using its deprecated version and will expire in version "Sodium".
local:
----------
          ID: linuxvda_xdping_tmpdir
    Function: file.directory
        Name: /tmp/citrix_linuxvda_tmp
      Result: True
     Comment: unless execution succeeded
     Started: 04:35:45.686618
    Duration: 1659.293 ms
     Changes:   
----------
          ID: linuxvda_xdping_download_archive
    Function: cmd.run
        Name: curl -o /tmp/citrix_linuxvda_tmp/linux-xdping.tar http://example.com/downloads/xendesktop/linux-xdping.tar
      Result: True
     Comment: Command "curl -o /tmp/citrix_linuxvda_tmp/linux-xdping.tar http://example.com/downloads/xendesktop/linux-xdping.tar" run
     Started: 04:35:47.347014
    Duration: 272.249 ms
     Changes:   
              ----------
              pid:
                  53066
              retcode:
                  0
              stderr:
                    % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                                   Dload  Upload   Total   Spent    Left  Speed
                  
                    0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
                  100 8420k  100 8420k    0     0  32.6M      0 --:--:-- --:--:-- --:--:-- 32.7M
              stdout:
----------
          ID: linuxvda_xdping-check-archive-hash
    Function: module.run
        Name: file.check_hash
      Result: True
     Comment: Module function file.check_hash executed
     Started: 04:35:47.622555
    Duration: 164.356 ms
     Changes:   
              ----------
              ret:
                  True
----------
          ID: linuxvda_xdping_archive_extract
    Function: archive.extracted
        Name: /tmp/citrix_linuxvda_tmp
      Result: True
     Comment: /tmp/citrix_linuxvda_tmp/linux-xdping.tar extracted to /tmp/citrix_linuxvda_tmp/, due to absence of one or more files/dirs
     Started: 04:35:47.789012
    Duration: 88.081 ms
     Changes:   
              ----------
              extracted_files:
                  - linux-xdping
                  - linux-xdping/RHEL
                  - linux-xdping/RHEL/xdping-7.13.1-0.x86_64.rpm
                  - linux-xdping/SuSE
                  - linux-xdping/SuSE/xdping-7.13.1-0.x86_64.rpm
                  - linux-xdping/Ubuntu
                  - linux-xdping/Ubuntu/xdping_7.13.1-0_amd64.deb
                  - linux-xdping/install.sh
                  - linux-xdping/uninstall.sh
                  - linux-xdping/Welcome.html
                  - linux-xdping/XDPing-7.13-ThirdPartyNotices.pdf
----------
          ID: linuxvda_xdping_package_install
    Function: cmd.run
        Name: /tmp/citrix_linuxvda_tmp/linux-xdping/uninstall.sh
      Result: True
     Comment: Command "/tmp/citrix_linuxvda_tmp/linux-xdping/uninstall.sh" run
     Started: 04:35:47.877438
    Duration: 1654.37 ms
     Changes:   
              ----------
              pid:
                  53070
              retcode:
                  0
              stderr:
              stdout:
                  (Reading database ... 225270 files and directories currently installed.)
                  Removing xdping (1.0.0.9999-0) ...
                  Processing triggers for libc-bin (2.23-0ubuntu10) ...
                  Processing triggers for man-db (2.7.5-1) ...
----------
          ID: linuxvda_xdping_package_install
    Function: pkg.installed
      Result: True
     Comment: The following packages were installed/updated: xdping
     Started: 04:35:49.548538
    Duration: 12167.418 ms
     Changes:   
              ----------
              xdping:
                  ----------
                  new:
                      1.0.0.9999-0
                  old:
----------
          ID: linuxvda_xdping_remove_tmpdir
    Function: file.absent
        Name: /tmp/citrix_linuxvda_tmp
      Result: True
     Comment: Removed directory /tmp/citrix_linuxvda_tmp
     Started: 04:36:01.721186
    Duration: 17.318 ms
     Changes:   
              ----------
              removed:
                  /tmp/citrix_linuxvda_tmp

Summary for local
------------
Succeeded: 7 (changed=6)
Failed:    0
------------
Total states run:     7
Total run time:  16.023 s
```
