### PR TITLE
Bugfix: Cleanup before Setup

### DIFF
--- a/linuxvda/config.sls
+++ b/linuxvda/config.sls
@@ -33,10 +33,17 @@ linuxvda_nsswitch_{{ config[0] }}:
     - require:
       - pkg: linuxvda_package
     - require_in:
-      - file: linuxvda_setup
+      - file: linuxvda_config_setup
   {% endfor %}
 
-linuxvda_setup:
+linuxvda_config_presetup:
+  cmd.run:
+    - name: {{ linuxvda.citrix.ctxcleanup }}
+    - onlyif: test -f {{ linuxvda.citrix.ctxcleanup }}
+    - require_in:
+      - file: linuxvda_config_setup 
+
+linuxvda_config_setup:
   file.managed:
     - name: {{ linuxvda.dl.tmpdir }}/vdasetup.sh
     - source: salt://linuxvda/files/vdasetup.sh


### PR DESCRIPTION
Fails on reruns - adding cleanup step before run.

 ```
 ID: linuxvda_setup
    Function: cmd.run
        Name: /tmp/citrix_linuxvda_tmp/vdasetup.sh
      Result: False
     Comment: Command "/tmp/citrix_linuxvda_tmp/vdasetup.sh" run
     Started: 04:53:25.537405
    Duration: 3816.039 ms
     Changes:
              ----------
              pid:
                  13999
              retcode:
                  1
              stderr:
              stdout:

                  Welcome to the Citrix Linux VDA setup script. This script will guide you through the
                  configuration of the Linux VDA system services. You can re-run this script at
                  any time to reconfigure the system.
                  
                  Gathering information...
                   ...
                  Configuring Citrix Linux VDA ...
                  Error occurred while attempting to apply.
                  Output:
                  Failed to create key '\Software\Citrix\VirtualDesktopAgent'.
                  Complete log can be found at "/tmp/xdl.configure.log".
                  Configuration failed.

```