### PR TITLE
Add CTX_XDL_FAS_LIST environ variable

### DIFF
--- a/linuxvda/config.sls
+++ b/linuxvda/config.sls
@@ -68,6 +68,7 @@ linuxvda_config_setup:
       CTX_XDL_HDX_3D_PRO: {{ linuxvda.citrix.variables.CTX_XDL_HDX_3D_PRO }}
       CTX_XDL_VDI_MODE: {{ linuxvda.citrix.variables.CTX_XDL_VDI_MODE }}
       CTX_XDL_START_SERVICE: {{ linuxvda.citrix.variables.CTX_XDL_START_SERVICE }}
+      CTX_XDL_FAS_LIST: {{ linuxvda.citrix.variables.CTX_XDL_FAS_LIST }}
   cmd.run:
     - name: {{ linuxvda.dl.tmpdir }}/vdasetup.sh
     - require:


### PR DESCRIPTION
PR to set environment variable during setup.  The variable is already in `defaults.yaml`.



> [CTX_XDL_FAS_LIST](https://docs.citrix.com/en-us/linux-virtual-delivery-agent/current-release/installation-overview/easy-install.html) = list-fas-servers – The Federated Authentication Service (FAS) servers are configured through AD Group Policy. Because the Linux VDA does not support AD Group Policy, you can provide a semicolon-separated list of FAS servers instead. The sequence must be the same as configured in AD Group Policy. If any server address is removed, fill its blank with the <none> text string and keep the sequence of server addresses without any changes.
